### PR TITLE
replacing hard-wired benchmark suites with benchmark factory

### DIFF
--- a/guacamol/benchmark_suites.py
+++ b/guacamol/benchmark_suites.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from sklearn.base import BaseEstimator
+
 from guacamol.distribution_learning_benchmark import DistributionLearningBenchmark, ValidityBenchmark, \
     UniquenessBenchmark
 from guacamol.goal_directed_benchmark import GoalDirectedBenchmark
@@ -10,16 +12,313 @@ from guacamol.standard_benchmarks import hard_cobimetinib, similarity, logP_benc
     kldiv_benchmark, perindopril_rings, amlodipine_rings, sitagliptin_replacement, zaleplon_with_other_formula, valsartan_smarts, \
     median_tadalafil_sildenafil, decoration_hop, scaffold_hop, ranolazine_mpo, pioglitazone_mpo
 
-
 def goal_directed_benchmark_suite(version_name: str) -> List[GoalDirectedBenchmark]:
-    if version_name == 'v1':
-        return goal_directed_suite_v1()
-    if version_name == 'v2':
-        return goal_directed_suite_v2()
-    if version_name == 'trivial':
-        return goal_directed_suite_trivial()
+    return GoalDirectedBenchmarkSuite().getBenchmark(version_name).getList()
 
-    raise Exception(f'Goal-directed benchmark suite "{version_name}" does not exist.')
+# factory (as singleton software engineering pattern)
+class GoalDirectedBenchmarkSuite(object):
+    class __GoalDirectedBenchmarkSuite:
+        def __init__(self):
+            self.register = {}
+
+        def getBenchmarkNames(self):
+            return sorted(self.register.keys())
+        
+        def getBenchmark(self,benchmark_name ):
+            if not len(benchmark_name):
+                raise ValueError("getBenchmark called with no benchmark_name")
+            benchmark=None
+            try:
+                benchmark = self.register[benchmark_name.lower()]
+            except:
+                error_msg="No Benchmark found named "+benchmark_name+"\nCurrently registered Benchmarks:\n\t"+"\n\t".join(self.register.keys())
+                raise Exception(error_msg)
+            return benchmark
+    instance = None
+    def __new__(cls): # __new__ always a classmethod
+        if not GoalDirectedBenchmarkSuite.instance:
+            GoalDirectedBenchmarkSuite.instance = GoalDirectedBenchmarkSuite.__GoalDirectedBenchmarkSuite()
+        return GoalDirectedBenchmarkSuite.instance
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+    def __setattr__(self, name):
+        return setattr(self.instance, name)
+
+
+# factory product
+class AbstractFactoryProduct(BaseEstimator):
+    def getHyperparameters(self):
+        hyperparameters=self.get_params()
+        return hyperparameters
+    def getHyperparametersDescription(self):
+        """Override me for the actual calculation"""
+        raise NotImplementedError
+    def getName(self):
+        """Override me for the actual calculation"""
+        raise NotImplementedError
+    def getNameFromHyperparameters(self, prefix):
+        description,abbreviation=self.getHyperparametersDescription()
+        hyperparameters=self.getHyperparameters()
+        
+        _name=prefix
+        for key in sorted (hyperparameters.keys()):
+            _name+="-"
+            _name+=abbreviation[key]
+            _name+=str(hyperparameters[key])
+        
+        return _name.lower()
+
+
+# factory product
+class GoalDirectedBenchmarkSuiteEntry(AbstractFactoryProduct):
+    def __init__(self):
+        GoalDirectedBenchmarkSuite().register[self.getName()] = self
+
+    def getList(self) -> List[GoalDirectedBenchmark]:
+        """Override me for the actual benchmark list"""
+        raise NotImplementedError
+
+
+#define
+class GoalDirectedV1(GoalDirectedBenchmarkSuiteEntry):
+    def __init__(self, max_logP = 6.35584):
+        self.max_logP=max_logP
+        GoalDirectedBenchmarkSuiteEntry.__init__(self)
+
+    def getName(self):
+        _name='v1'
+        return _name.lower()
+
+    def getHyperparametersDescription(self):
+        description={}
+        abbreviation={}
+        return description,abbreviation
+
+    def getList(self) -> List[GoalDirectedBenchmark]:
+        max_logP = self.max_logP
+        return [
+            isomers_c11h24(mean_function='arithmetic'),
+            isomers_c7h8n2o2(mean_function='arithmetic'),
+            isomers_c9h10n2o2pf2cl(mean_function='arithmetic', n_samples=100),
+       
+            hard_cobimetinib(max_logP=max_logP),
+            hard_osimertinib(ArithmeticMeanScoringFunction),
+            hard_fexofenadine(ArithmeticMeanScoringFunction),
+            weird_physchem(),
+       
+            # start pop benchmark
+            # e.g.
+            start_pop_ranolazine(),
+       
+            # similarity Benchmarks
+       
+            # explicit rediscovery
+            similarity(smiles='CC1=CC=C(C=C1)C1=CC(=NN1C1=CC=C(C=C1)S(N)(=O)=O)C(F)(F)F', name='Celecoxib', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+            similarity(smiles='Cc1c(C)c2OC(C)(COc3ccc(CC4SC(=O)NC4=O)cc3)CCc2c(C)c1O', name='Troglitazone', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+            similarity(smiles='CN(C)S(=O)(=O)c1ccc2Sc3ccccc3C(=CCCN4CCN(C)CC4)c2c1', name='Thiothixene', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+       
+            # generate similar stuff
+            similarity(smiles='Clc4cccc(N3CCN(CCCCOc2ccc1c(NC(=O)CC1)c2)CC3)c4Cl', name='Aripiprazole', fp_type='FCFP4', threshold=0.75),
+            similarity(smiles='CC(C)(C)NCC(O)c1ccc(O)c(CO)c1', name='Albuterol', fp_type='FCFP4', threshold=0.75),
+            similarity(smiles='COc1ccc2[C@H]3CC[C@@]4(C)[C@@H](CC[C@@]4(O)C#C)[C@@H]3CCc2c1', name='Mestranol', fp_type='AP', threshold=0.75),
+       
+            logP_benchmark(target=-1.0),
+            logP_benchmark(target=8.0),
+            tpsa_benchmark(target=150.0),
+       
+            cns_mpo(max_logP=max_logP),
+            qed_benchmark(),
+            median_camphor_menthol(ArithmeticMeanScoringFunction)
+        ]
+
+#register
+GoalDirectedV1()
+
+#define
+class GoalDirectedV2(GoalDirectedBenchmarkSuiteEntry):
+    def __init__(self):
+        GoalDirectedBenchmarkSuiteEntry.__init__(self)
+
+    def getName(self):
+        _name='v2'
+        return _name.lower()
+
+    def getHyperparametersDescription(self):
+        description={}
+        abbreviation={}
+        return description,abbreviation
+
+    def getList(self) -> List[GoalDirectedBenchmark]:
+        return [
+            # explicit rediscovery
+            similarity(smiles='CC1=CC=C(C=C1)C1=CC(=NN1C1=CC=C(C=C1)S(N)(=O)=O)C(F)(F)F', name='Celecoxib', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+            similarity(smiles='Cc1c(C)c2OC(C)(COc3ccc(CC4SC(=O)NC4=O)cc3)CCc2c(C)c1O', name='Troglitazone', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+            similarity(smiles='CN(C)S(=O)(=O)c1ccc2Sc3ccccc3C(=CCCN4CCN(C)CC4)c2c1', name='Thiothixene', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+       
+            # generate similar stuff
+            similarity(smiles='Clc4cccc(N3CCN(CCCCOc2ccc1c(NC(=O)CC1)c2)CC3)c4Cl', name='Aripiprazole', fp_type='ECFP4', threshold=0.75),
+            similarity(smiles='CC(C)(C)NCC(O)c1ccc(O)c(CO)c1', name='Albuterol', fp_type='FCFP4', threshold=0.75),
+            similarity(smiles='COc1ccc2[C@H]3CC[C@@]4(C)[C@@H](CC[C@@]4(O)C#C)[C@@H]3CCc2c1', name='Mestranol', fp_type='AP', threshold=0.75),
+       
+            # isomers
+            isomers_c11h24(),
+            isomers_c9h10n2o2pf2cl(),
+       
+            # median molecules
+            median_camphor_menthol(),
+            median_tadalafil_sildenafil(),
+       
+            # all other MPOs
+            hard_osimertinib(),
+            hard_fexofenadine(),
+            ranolazine_mpo(),
+            perindopril_rings(),
+            amlodipine_rings(),
+            sitagliptin_replacement(),
+            zaleplon_with_other_formula(),
+            valsartan_smarts(),
+            decoration_hop(),
+            scaffold_hop(),
+        ]
+    
+#register
+GoalDirectedV2()
+
+#define
+class GoalDirectedTrivial(GoalDirectedBenchmarkSuiteEntry):
+    def __init__(self):
+        GoalDirectedBenchmarkSuiteEntry.__init__(self)
+
+    def getName(self):
+        _name='trivial'
+        return _name.lower()
+
+    def getHyperparametersDescription(self):
+        description={}
+        abbreviation={}
+        return description,abbreviation
+
+    def getList(self) -> List[GoalDirectedBenchmark]:
+        """
+        Trivial goal-directed benchmarks from the paper.
+        """
+        return [
+            logP_benchmark(target=-1.0),
+            logP_benchmark(target=8.0),
+            tpsa_benchmark(target=150.0),
+            cns_mpo(),
+            qed_benchmark(),
+            isomers_c7h8n2o2(),
+            pioglitazone_mpo(),
+        ]
+
+#register
+GoalDirectedTrivial()
+
+
+#define
+class GoalDirectedAll(GoalDirectedBenchmarkSuiteEntry):
+    def __init__(self, max_logP = 6.35584):
+        self.max_logP=max_logP
+        GoalDirectedBenchmarkSuiteEntry.__init__(self)
+
+    def getName(self):
+        _name='all'
+        return _name.lower()
+
+    def getHyperparametersDescription(self):
+        description={}
+        abbreviation={}
+        return description,abbreviation
+
+    def getList(self) -> List[GoalDirectedBenchmark]:
+        max_logP = self.max_logP
+        return [
+            # explicit rediscovery
+            similarity(smiles='CC1=CC=C(C=C1)C1=CC(=NN1C1=CC=C(C=C1)S(N)(=O)=O)C(F)(F)F', name='Celecoxib', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+            similarity(smiles='Cc1c(C)c2OC(C)(COc3ccc(CC4SC(=O)NC4=O)cc3)CCc2c(C)c1O', name='Troglitazone', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+            similarity(smiles='CN(C)S(=O)(=O)c1ccc2Sc3ccccc3C(=CCCN4CCN(C)CC4)c2c1', name='Thiothixene', fp_type='ECFP4', threshold=1.0, rediscovery=True),
+       
+            # generate similar stuff
+            similarity(smiles='Clc4cccc(N3CCN(CCCCOc2ccc1c(NC(=O)CC1)c2)CC3)c4Cl', name='Aripiprazole', fp_type='ECFP4', threshold=0.75),
+            similarity(smiles='CC(C)(C)NCC(O)c1ccc(O)c(CO)c1', name='Albuterol', fp_type='FCFP4', threshold=0.75),
+            similarity(smiles='COc1ccc2[C@H]3CC[C@@]4(C)[C@@H](CC[C@@]4(O)C#C)[C@@H]3CCc2c1', name='Mestranol', fp_type='AP', threshold=0.75),
+       
+            # isomers
+            isomers_c7h8n2o2(),
+            isomers_c7h8n2o2(mean_function='arithmetic'),
+            isomers_c11h24(),
+            isomers_c11h24(mean_function='arithmetic'),
+            isomers_c9h10n2o2pf2cl(),
+            isomers_c9h10n2o2pf2cl(mean_function='arithmetic', n_samples=100),
+       
+            # median molecules
+            median_camphor_menthol(),
+            median_camphor_menthol(ArithmeticMeanScoringFunction),
+            median_tadalafil_sildenafil(),
+       
+            # start pop benchmark
+            # e.g.
+            start_pop_ranolazine(),
+
+            # scaffold and decoration hopping
+            decoration_hop(),
+            scaffold_hop(),
+
+            # all other MPOs
+            amlodipine_rings(),
+            cns_mpo(),
+            cns_mpo(max_logP=max_logP),
+            hard_cobimetinib(max_logP=max_logP),
+            hard_fexofenadine(),
+            hard_fexofenadine(ArithmeticMeanScoringFunction),
+            hard_osimertinib(),
+            hard_osimertinib(ArithmeticMeanScoringFunction),
+            logP_benchmark(target=-1.0),
+            logP_benchmark(target=8.0),
+            perindopril_rings(),
+            pioglitazone_mpo(),
+            qed_benchmark(),
+            ranolazine_mpo(),
+            sitagliptin_replacement(),
+            tpsa_benchmark(target=150.0),
+            valsartan_smarts(),
+            weird_physchem(),
+            zaleplon_with_other_formula(),
+        ]
+    
+#register
+GoalDirectedAll()
+
+
+# factory (as singleton software engineering pattern)
+class DistributionLearningBenchmarkSuite(object):
+    class __DistributionLearningBenchmarkSuite:
+        def __init__(self):
+            self.register = {}
+
+        def getBenchmarkNames(self):
+            return sorted(self.register.keys())
+        
+        def getBenchmark(self,benchmark_name ):
+            if not len(benchmark_name):
+                raise ValueError("getBenchmark called with no benchmark_name")
+            benchmark=None
+            try:
+                benchmark = self.register[benchmark_name.lower()]
+            except:
+                error_msg="No Benchmark found named "+benchmark_name+"\nCurrently registered Benchmarks:\n\t"+"\n\t".join(self.register.keys())
+                raise Exception(error_msg)
+            return benchmark
+    instance = None
+    def __new__(cls): # __new__ always a classmethod
+        if not DistributionLearningBenchmarkSuite.instance:
+            DistributionLearningBenchmarkSuite.instance = DistributionLearningBenchmarkSuite.__DistributionLearningBenchmarkSuite()
+        return DistributionLearningBenchmarkSuite.instance
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+    def __setattr__(self, name):
+        return setattr(self.instance, name)
 
 
 def distribution_learning_benchmark_suite(chembl_file_path: str,
@@ -37,125 +336,60 @@ def distribution_learning_benchmark_suite(chembl_file_path: str,
     """
 
     # For distribution-learning, v1 and v2 are identical
-    if version_name == 'v1' or version_name == 'v2':
-        return distribution_learning_suite_v1(chembl_file_path=chembl_file_path, number_samples=number_samples)
+    #register, of not already registered
+    if not (version_name in DistributionLearningBenchmarkSuiteEntry().getBenchmarkNames()):
+        DistributionLearningV1(chembl_file_path=chembl_file_path, number_samples=number_samples)
+        DistributionLearningV1(registerAsName='v2',chembl_file_path=chembl_file_path, number_samples=number_samples)
 
-    raise Exception(f'Distribution-learning benchmark suite "{version_name}" does not exist.')
+    #return
+    return DistributionLearningBenchmarkSuiteEntry().getBenchmark(version_name).getList()
 
+# factory product
+class DistributionLearningBenchmarkSuiteEntry(AbstractFactoryProduct):
+    def __init__(self):
+        DistributionLearningBenchmarkSuite().register[self.getName()] = self
 
-def goal_directed_suite_v1() -> List[GoalDirectedBenchmark]:
-    max_logP = 6.35584
-    return [
-        isomers_c11h24(mean_function='arithmetic'),
-        isomers_c7h8n2o2(mean_function='arithmetic'),
-        isomers_c9h10n2o2pf2cl(mean_function='arithmetic', n_samples=100),
-
-        hard_cobimetinib(max_logP=max_logP),
-        hard_osimertinib(ArithmeticMeanScoringFunction),
-        hard_fexofenadine(ArithmeticMeanScoringFunction),
-        weird_physchem(),
-
-        # start pop benchmark
-        # e.g.
-        start_pop_ranolazine(),
-
-        # similarity Benchmarks
-
-        # explicit rediscovery
-        similarity(smiles='CC1=CC=C(C=C1)C1=CC(=NN1C1=CC=C(C=C1)S(N)(=O)=O)C(F)(F)F', name='Celecoxib',
-                   fp_type='ECFP4', threshold=1.0, rediscovery=True),
-        similarity(smiles='Cc1c(C)c2OC(C)(COc3ccc(CC4SC(=O)NC4=O)cc3)CCc2c(C)c1O', name='Troglitazone',
-                   fp_type='ECFP4', threshold=1.0, rediscovery=True),
-        similarity(smiles='CN(C)S(=O)(=O)c1ccc2Sc3ccccc3C(=CCCN4CCN(C)CC4)c2c1', name='Thiothixene',
-                   fp_type='ECFP4', threshold=1.0, rediscovery=True),
-
-        # generate similar stuff
-        similarity(smiles='Clc4cccc(N3CCN(CCCCOc2ccc1c(NC(=O)CC1)c2)CC3)c4Cl',
-                   name='Aripiprazole', fp_type='FCFP4', threshold=0.75),
-        similarity(smiles='CC(C)(C)NCC(O)c1ccc(O)c(CO)c1', name='Albuterol',
-                   fp_type='FCFP4', threshold=0.75),
-        similarity(smiles='COc1ccc2[C@H]3CC[C@@]4(C)[C@@H](CC[C@@]4(O)C#C)[C@@H]3CCc2c1', name='Mestranol',
-                   fp_type='AP', threshold=0.75),
-
-        logP_benchmark(target=-1.0),
-        logP_benchmark(target=8.0),
-        tpsa_benchmark(target=150.0),
-
-        cns_mpo(max_logP=max_logP),
-        qed_benchmark(),
-        median_camphor_menthol(ArithmeticMeanScoringFunction)
-    ]
+    def getList(self) -> List[DistributionLearningBenchmark]:
+        """Override me for the actual benchmark list"""
+        raise NotImplementedError
 
 
-def goal_directed_suite_v2() -> List[GoalDirectedBenchmark]:
-    return [
-        # explicit rediscovery
-        similarity(smiles='CC1=CC=C(C=C1)C1=CC(=NN1C1=CC=C(C=C1)S(N)(=O)=O)C(F)(F)F', name='Celecoxib', fp_type='ECFP4',
-                   threshold=1.0, rediscovery=True),
-        similarity(smiles='Cc1c(C)c2OC(C)(COc3ccc(CC4SC(=O)NC4=O)cc3)CCc2c(C)c1O', name='Troglitazone', fp_type='ECFP4',
-                   threshold=1.0, rediscovery=True),
-        similarity(smiles='CN(C)S(=O)(=O)c1ccc2Sc3ccccc3C(=CCCN4CCN(C)CC4)c2c1', name='Thiothixene', fp_type='ECFP4',
-                   threshold=1.0, rediscovery=True),
+#define
+class DistributionLearningV1(DistributionLearningBenchmarkSuiteEntry):
+    def __init__(self, registerAsName=None, chembl_file_path: str = None, number_samples: int = 10000):
+        self.registerAsName=registerAsName
+        self.chembl_file_path=chembl_file_path
+        self.number_samples=number_samples
+        DistributionLearningBenchmarkSuiteEntry.__init__(self)
 
-        # generate similar stuff
-        similarity(smiles='Clc4cccc(N3CCN(CCCCOc2ccc1c(NC(=O)CC1)c2)CC3)c4Cl', name='Aripiprazole', fp_type='ECFP4',
-                   threshold=0.75),
-        similarity(smiles='CC(C)(C)NCC(O)c1ccc(O)c(CO)c1', name='Albuterol', fp_type='FCFP4', threshold=0.75),
-        similarity(smiles='COc1ccc2[C@H]3CC[C@@]4(C)[C@@H](CC[C@@]4(O)C#C)[C@@H]3CCc2c1', name='Mestranol',
-                   fp_type='AP', threshold=0.75),
+    def getName(self):
+        _name='v1'
+        if self.registerAsName is not None:
+            _name=self.registerAsName
+        return _name.lower()
 
-        # isomers
-        isomers_c11h24(),
-        isomers_c9h10n2o2pf2cl(),
+    def getHyperparametersDescription(self):
+        description={}
+        abbreviation={}
+        return description,abbreviation
 
-        # median molecules
-        median_camphor_menthol(),
-        median_tadalafil_sildenafil(),
-
-        # all other MPOs
-        hard_osimertinib(),
-        hard_fexofenadine(),
-        ranolazine_mpo(),
-        perindopril_rings(),
-        amlodipine_rings(),
-        sitagliptin_replacement(),
-        zaleplon_with_other_formula(),
-        valsartan_smarts(),
-        decoration_hop(),
-        scaffold_hop(),
-    ]
-
-
-def goal_directed_suite_trivial() -> List[GoalDirectedBenchmark]:
-    """
-    Trivial goal-directed benchmarks from the paper.
-    """
-    return [
-        logP_benchmark(target=-1.0),
-        logP_benchmark(target=8.0),
-        tpsa_benchmark(target=150.0),
-        cns_mpo(),
-        qed_benchmark(),
-        isomers_c7h8n2o2(),
-        pioglitazone_mpo(),
-    ]
+    def getList(self) -> List[DistributionLearningBenchmark]:
+        """
+        Suite of distribution learning benchmarks, v1.
+    
+        Args:
+            chembl_file_path: path to the file with the reference ChEMBL molecules
+    
+        Returns:
+            List of benchmarks, version 1
+        """
+        return [
+            ValidityBenchmark(number_samples=self.number_samples),
+            UniquenessBenchmark(number_samples=self.number_samples),
+            novelty_benchmark(training_set_file=self.chembl_file_path, number_samples=self.number_samples),
+            kldiv_benchmark(training_set_file=self.chembl_file_path, number_samples=self.number_samples),
+            frechet_benchmark(training_set_file=self.chembl_file_path, number_samples=self.number_samples)
+        ]
+    
 
 
-def distribution_learning_suite_v1(chembl_file_path: str, number_samples: int = 10000) -> \
-        List[DistributionLearningBenchmark]:
-    """
-    Suite of distribution learning benchmarks, v1.
-
-    Args:
-        chembl_file_path: path to the file with the reference ChEMBL molecules
-
-    Returns:
-        List of benchmarks, version 1
-    """
-    return [
-        ValidityBenchmark(number_samples=number_samples),
-        UniquenessBenchmark(number_samples=number_samples),
-        novelty_benchmark(training_set_file=chembl_file_path, number_samples=number_samples),
-        kldiv_benchmark(training_set_file=chembl_file_path, number_samples=number_samples),
-        frechet_benchmark(training_set_file=chembl_file_path, number_samples=number_samples)
-    ]


### PR DESCRIPTION
Dear all, could we please replace the hard-wired benchmark suites with a "benchmark factory" (software engineering) pattern. Here I chose a "singleton pattern" as "factory pattern".
Any benchmark version self-registers itself with a name like "v1, "v2, "trivial", but more importantly, it enables to register other benchmarks we might be interested in without changing the guacamol package code.

Penny for your thoughts.

Also, any thought on how we could load goal-oriented benchmarks from file rather? I realize its non-trivial, but maybe at least some we could load from files, as the hard-wired coding is too inflexible for accumulating bigger benchmarks we might be interested in.