### PR TITLE
Change histogram import

### DIFF
--- a/guacamol/frechet_benchmark.py
+++ b/guacamol/frechet_benchmark.py
@@ -25,7 +25,7 @@ class FrechetBenchmark(DistributionLearningBenchmark):
     """
 
     def __init__(self, training_set: List[str],
-                 chemnet_model_filename='ChemNet_v0.13_pretrained.h5',
+                 chemnet_model_filename='ChemNet_v0.13_pretrained.pt',
                  sample_size=10000) -> None:
         """
         Args:

--- a/guacamol/utils/chemistry.py
+++ b/guacamol/utils/chemistry.py
@@ -7,7 +7,7 @@ from rdkit import Chem
 from rdkit import RDLogger, DataStructs
 from rdkit.Chem import AllChem
 from rdkit.ML.Descriptors import MoleculeDescriptors
-from scipy import histogram
+from numpy import histogram
 from scipy.stats import entropy, gaussian_kde
 
 from guacamol.utils.data import remove_duplicates


### PR DESCRIPTION
Histogram has been removed in `scipy` but is available in `numpy` The requirement `numpy>=1.15.2` covers the import.